### PR TITLE
Local Partial Grading

### DIFF
--- a/api.go
+++ b/api.go
@@ -160,6 +160,7 @@ func Server() {
 
 				result.Student = dir
 
+				result.Feedback = make([]string, 1)
 				// find hydratedStudent information from studentId (query param)
 				intStudentId, err := strconv.Atoi(studentId)
 				util.Throw(err)

--- a/api.go
+++ b/api.go
@@ -55,7 +55,6 @@ func Server() {
 			util.Throw(err)
 			supabaseKey := os.Getenv("SUPABASE_KEY")
 
-
 			// Init supabase client
 			supabase := initSupabase()
 
@@ -100,7 +99,7 @@ func Server() {
 			}
 
 			// Prepare request object to send files from form to bucket
-			bucketUrl := supabase.BaseURL + "/" + "storage/v1/object/assignments/" + assignmentId + "/"
+			bucketUrl := supabase.BaseURL + "/storage/v1/object/assignments/" + assignmentId + "/"
 			client := &http.Client{}
 			// Iterate over multipart form files with name="code" and build local submissions directory
 			for _, header := range r.MultipartForm.File["code"] {
@@ -160,7 +159,7 @@ func Server() {
 				results.Order = append(results.Order, dir)
 
 				result.Student = dir
-				
+
 				// find hydratedStudent information from studentId (query param)
 				intStudentId, err := strconv.Atoi(studentId)
 				util.Throw(err)
@@ -181,14 +180,14 @@ func Server() {
 				if assignment.Language == "python3" || assignment.Language == "python" {
 					result.CompileSuccess = true
 
-				 stdout := runInterpreted(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input)
+					stdout := runInterpreted(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input)
 					fmt.Printf("Output for %s: %s", result.Student, stdout)
-					result.RunCorrect, result.Feedback = compare(expected, stdout)
+					_, result.Feedback[0] = compare(expected, stdout)
 				} else {
 					result.CompileSuccess = compile(filepath.Join(workDir, dir), assignment.Language, false)
 					if result.CompileSuccess {
 						stdout := runCompiled(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input)
-						result.RunCorrect, result.Feedback = processOutput(expected, stdout)
+						result.Feedback[0] = processOutput(expected, stdout)
 					}
 				}
 			}

--- a/db/main.go
+++ b/db/main.go
@@ -48,10 +48,10 @@ func toDbAssignment(assignment util.SubmissionResult) DbSubmission {
 		Assignment:    assignment.AssignmentId,
 		Student:       assignment.StudentId,
 		IsLate:        false,
-		Score:         int8(util.CalculateScore(assignment)),
+		Score:         assignment.Score,
 		Flags:         []string{},
 		SubmissionLoc: "UNDEF",
-		Feedback:      assignment.Feedback,
+		Feedback:      util.StringSliceToPrettyString(assignment.Feedback),
 	}
 }
 

--- a/grade.go
+++ b/grade.go
@@ -405,8 +405,11 @@ func main() {
 		for i, test := range ogInfo.Tests {
 			expected := util.GetFile(workDir + "/.spec/" + test.Expected)
 			fmt.Print("Expected Output: ", expected, "\n\n")
-
-			input := parseInFile(workDir + "/.spec/" + test.Input)
+			var input = []string{}
+			if test.Input != "" {
+				input = parseInFile(workDir + "/.spec/" + test.Input)
+			}
+			
 			gradeSubmission(&result, dir, workDir, runArgs, expected, language, input, wall, i)
 
 		}

--- a/grade.go
+++ b/grade.go
@@ -164,7 +164,7 @@ func createCsv(results util.SubmissionResults, outfile string) {
 	util.Throw(err)
 
 	writer := csv.NewWriter(file)
-	writer.Write([]string{"student", "compiled", "ran correctly", "feedback"})
+	writer.Write([]string{"student", "compiled", "score", "feedback"})
 	for _, id := range results.Order {
 		result := results.Results[id]
 		row := []string{result.Student, btoa(result.CompileSuccess), fmt.Sprint(result.Score), util.StringSliceToPrettyString(result.Feedback)}

--- a/grade.go
+++ b/grade.go
@@ -421,7 +421,7 @@ func main() {
 		}
 	}
 	for _, id := range results.Order {
-		fmt.Printf("%s: [compileSuccess=%t] [runCorrect=%d] \n", id, results.Results[id].CompileSuccess, results.Results[id].Score)
+		fmt.Printf("%s: [compileSuccess=%t] [score=%d] \n", id, results.Results[id].CompileSuccess, results.Results[id].Score)
 	}
 	if !isDryRun {
 		writeFullOutputToDb(supabase, results)

--- a/grade_test.go
+++ b/grade_test.go
@@ -144,7 +144,7 @@ func TestCreateCsv(t *testing.T) {
 
 	createCsv(res, tmp.Name())
 
-	expected := `student,compiled,ran correctly,feedback
+	expected := `student,compiled,score,feedback
 aaa0001,true,100,<diff1>
 bbb0002,true,50,<diff2>
 ccc0003,false,50,<diff3>

--- a/util/main.go
+++ b/util/main.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 )
 
 // Collection of submission results. Includes an order array to indicate the order of items in the
@@ -14,25 +16,36 @@ type SubmissionResults struct {
 
 // Record of a student's submission, with metadata about how it ran and compiled.
 type SubmissionResult struct {
-	Student        string
-	CompileSuccess bool
-	RunCorrect     bool
-	Feedback       string
-	AssignmentId   int8
-	StudentId      int8
+	Student        	string
+	CompileSuccess 	bool
+	Score						int8
+	Feedback       	[]string
+	AssignmentId   	int8
+	StudentId      	int8
+}
+
+type Test struct {
+	Expected 	string 	`json:"Expected"`
+	Input 		string	`json:"Input"`
+	Weight 		int8		`json:"Weight"`
 }
 
 type AssignmentInfo struct {
-	AssignmentId int8
+	AssignmentId 	int8		`json:"AssignmentId"`
+	Tests 				[]Test	`json:"Tests"`
 }
 
-func CalculateScore(result SubmissionResult) (score int) {
-	if result.CompileSuccess {
-		score += 50
+func CalculateScore(result SubmissionResult, tests []Test) (score int) {
+	var scorePossible int = 0
+	var scoreEarned int = 0
+	for i, feedback := range result.Feedback {
+		scorePossible += int(tests[i].Weight)
+		if feedback == "" {
+			scoreEarned += int(tests[i].Weight)
+		}
 	}
-	if result.RunCorrect {
-		score += 50
-	}
+
+	score = int((float64(scoreEarned) / float64(scorePossible)) * 100)
 	return
 }
 
@@ -61,4 +74,15 @@ func ParseOgInfo(path string) (info AssignmentInfo) {
 
 	json.Unmarshal(data, &info)
 	return
+}
+
+// Helper method to turn string slice into a readable, new line separated string that will print well in the report
+func StringSliceToPrettyString(input []string) string {
+	var output string = ""
+	for _, str := range input {
+		if str != "" {
+			output += fmt.Sprintf("%s\n", str)
+		}
+	}
+	return strings.TrimSpace(output)
 }

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"testing"
 )
@@ -10,44 +9,64 @@ import (
 // Write unit tests for the util package.
 
 func TestCalculateScore(t *testing.T) {
+	// Test cases for CalculateScore
 	var tests = []struct {
 		result SubmissionResult
+		tests  []Test
 		want   int
 	}{
 		{
 			SubmissionResult{
+				Student:        "test",
 				CompileSuccess: true,
-				RunCorrect:     true,
+				Score:          0,
+				Feedback:       []string{"", ""},
+				AssignmentId:   1,
+				StudentId:      1,
+			},
+			[]Test{
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
 			},
 			100,
 		},
 		{
 			SubmissionResult{
-				CompileSuccess: false,
-				RunCorrect:     true,
-			},
-			50,
-		},
-		{
-			SubmissionResult{
+				Student:        "test",
 				CompileSuccess: true,
-				RunCorrect:     false,
+				Score:        0,	
+				Feedback:     []string{"", "test"},
+				AssignmentId: 1,
+				StudentId:    1,
+			},
+			[]Test{	
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
 			},
 			50,
-		},
-		{
-			SubmissionResult{
-				CompileSuccess: false,
-				RunCorrect:     false,
-			},
-			0,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run("TestCalculateScore", func(t *testing.T) {
-			if got := CalculateScore(test.result); got != test.want {
-				t.Errorf("CalculateScore(%v) = %v, want %v", test.result, got, test.want)
+			if got := CalculateScore(test.result, test.tests); got != test.want {
+				t.Errorf("CalculateScore(%v, %v) = %v, want %v", test.result, test.tests, got, test.want)
 			}
 		})
 	}
@@ -110,34 +129,83 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestParseOgInfo(t *testing.T) {
-	var tests = []struct {
-		path string
-		want AssignmentInfo
-	}{
-		{
-			"test.json",
-			AssignmentInfo{
-				AssignmentId: 1,
+
+	var want = AssignmentInfo{
+		AssignmentId: 1,
+		Tests: []Test{
+			{
+				Expected: "test1/out.txt",
+				Input: "test1/in.txt",
+				Weight: 50,
 			},
-		},
-		{
-			"test2.json",
-			AssignmentInfo{
-				AssignmentId: 2,
+			{
+				Expected: "test2/out.txt",
+				Input: "test2/in.txt",
+				Weight: 10,
+			},
+			{
+				Expected: "test3/out.txt",
+				Input: "test3/in.txt",
+				Weight: 15,
+			},
+			{
+				Expected: "test4/out.txt",
+				Input: "test4/in.txt",
+				Weight: 25,
 			},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run("TestParseOgInfo", func(t *testing.T) {
-			target, _ := os.CreateTemp("", test.path)
-			defer os.Remove(target.Name())
 
-			os.WriteFile(target.Name(), []byte(fmt.Sprintf(`{"assignmentId": %d}`, test.want.AssignmentId)), os.ModeAppend)
 
-			if got := ParseOgInfo(target.Name()); got != test.want {
-				t.Errorf("ParseOgInfo(%v) = %v, want %v", test.path, got, test.want)
-			}
-		})
+	oginfo := `{
+		"AssignmentId": 1,
+		"Tests": [
+			{
+				"Expected": "test1/out.txt",
+				"Input": "test1/in.txt",
+				"Weight": 50
+			},
+			{
+				"Expected": "test2/out.txt",
+				"Input": "test2/in.txt",
+				"Weight": 10
+
+			},
+			{
+				"Expected": "test3/out.txt",
+				"Input": "test3/in.txt",
+				"Weight": 15
+			},
+			{
+				"Expected": "test4/out.txt",
+				"Input": "test4/in.txt",
+				"Weight": 25
+			} 
+		]
+	}`
+
+	tmp, _ := os.CreateTemp("", "test.json")
+	defer os.Remove(tmp.Name())
+
+	os.WriteFile(tmp.Name(), []byte(oginfo), os.ModeAppend)
+	
+	got := ParseOgInfo(tmp.Name())
+
+	if got.AssignmentId != want.AssignmentId {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
 	}
+
+	for i := range got.Tests {
+		if got.Tests[i].Expected != want.Tests[i].Expected {
+			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+		}
+		if got.Tests[i].Input != want.Tests[i].Input {
+			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+		}
+		if got.Tests[i].Weight != want.Tests[i].Weight {
+			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+		}
+	}
+
 }


### PR DESCRIPTION
The engine now has local support for partial grading by using a set of tests with weights as defined by `/.spec/oginfo.json`.

`oginfo.json` should resemble the following schema:
```json
{
  "AssignmentId": 4,
  "Tests": [
    {
      "Expected": "test1/out.txt",
      "Input": "test1/in.txt",
      "Weight": 50
    },
    {
      "Expected": "test2/out.txt",
      "Input": "test2/in.txt",
      "Weight": 10

    },
    {
      "Expected": "test3/out.txt",
      "Input": "test3/in.txt",
      "Weight": 15
    },
    {
      "Expected": "test4/out.txt",
      "Input": "test4/in.txt",
      "Weight": 25
    } 
  ]
}
```
with a corresponding submissions directory looking like this: 
```txt
Submissions/
├── .spec
│   ├── oginfo.json
│   ├── test1
│   │   ├── in.txt
│   │   └── out.txt
│   ├── test2
│   │   ├── in.txt
│   │   └── out.txt
│   ├── test3
│   │   ├── in.txt
│   │   └── out.txt
│   └── test4
│       ├── in.txt
│       └── out.txt
├── dcf0083
│   └── dcf_hw1.cpp
├── dgg0018
│    └── dgg_hw1.cpp
└──...
```

The only other noteworthy change _besides_ partial grading is that I removed the `-in` flag, as it is no longer needed since the input file is declared in `oginfo.json`.

The API will be updated in a later PR once all of the features using `oginfo.json` are complete. The API is still working just as it was last sprint, so its not broken or anything, just makes more sense to wait. 
