### PR TITLE
Expanded `oginfo.json` capabilities

### DIFF
--- a/api.go
+++ b/api.go
@@ -55,7 +55,6 @@ func Server() {
 			util.Throw(err)
 			supabaseKey := os.Getenv("SUPABASE_KEY")
 
-
 			// Init supabase client
 			supabase := initSupabase()
 
@@ -100,7 +99,7 @@ func Server() {
 			}
 
 			// Prepare request object to send files from form to bucket
-			bucketUrl := supabase.BaseURL + "/" + "storage/v1/object/assignments/" + assignmentId + "/"
+			bucketUrl := supabase.BaseURL + "/storage/v1/object/assignments/" + assignmentId + "/"
 			client := &http.Client{}
 			// Iterate over multipart form files with name="code" and build local submissions directory
 			for _, header := range r.MultipartForm.File["code"] {
@@ -160,7 +159,7 @@ func Server() {
 				results.Order = append(results.Order, dir)
 
 				result.Student = dir
-				
+
 				// find hydratedStudent information from studentId (query param)
 				intStudentId, err := strconv.Atoi(studentId)
 				util.Throw(err)
@@ -181,14 +180,14 @@ func Server() {
 				if assignment.Language == "python3" || assignment.Language == "python" {
 					result.CompileSuccess = true
 
-				 stdout := runInterpreted(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input)
+					stdout := runInterpreted(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input)
 					fmt.Printf("Output for %s: %s", result.Student, stdout)
-					result.RunCorrect, result.Feedback = compare(expected, stdout)
+					_, result.Feedback[0] = compare(expected, stdout)
 				} else {
 					result.CompileSuccess = compile(filepath.Join(workDir, dir), assignment.Language, false)
 					if result.CompileSuccess {
 						stdout := runCompiled(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input)
-						result.RunCorrect, result.Feedback = processOutput(expected, stdout)
+						result.Feedback[0] = processOutput(expected, stdout)
 					}
 				}
 			}

--- a/db/main.go
+++ b/db/main.go
@@ -48,10 +48,10 @@ func toDbAssignment(assignment util.SubmissionResult) DbSubmission {
 		Assignment:    assignment.AssignmentId,
 		Student:       assignment.StudentId,
 		IsLate:        false,
-		Score:         int8(util.CalculateScore(assignment)),
+		Score:         assignment.Score,
 		Flags:         []string{},
 		SubmissionLoc: "UNDEF",
-		Feedback:      assignment.Feedback,
+		Feedback:      util.StringSliceToPrettyString(assignment.Feedback),
 	}
 }
 

--- a/grade.go
+++ b/grade.go
@@ -404,13 +404,35 @@ func main() {
 
 		for i, test := range ogInfo.Tests {
 			expected := util.GetFile(workDir + "/.spec/" + test.Expected)
-			fmt.Print("Expected Output: ", expected, "\n\n")
+
+			if test.Open {
+				fmt.Printf("Test #%d Expected Output:\n%s\n\n", i, expected)
+			}
+			
 			var input = []string{}
 			if test.Input != "" {
 				input = parseInFile(workDir + "/.spec/" + test.Input)
 			}
 			
 			gradeSubmission(&result, dir, workDir, runArgs, expected, language, input, wall, i)
+			
+			
+			var testResult string
+			if result.CompileSuccess && result.Feedback[i] == ""  {
+				testResult = "PASS"
+			} else {
+				testResult = "FAIL"
+			}
+
+			fmt.Printf("Test #%d Result:\n%s\n\n", i, testResult)
+
+			if result.CompileSuccess && test.Open {
+				fmt.Printf("Test #%d Feedback:\n%s\n\n", i, result.Feedback[i])
+			}
+			
+			if !result.CompileSuccess && test.Open {
+				fmt.Printf("Test #%d Feedback:\nCompilation failed.\n\n", i)
+			}
 
 		}
 

--- a/grade.go
+++ b/grade.go
@@ -482,7 +482,6 @@ func main() {
 				fmt.Printf("Test #%d Feedback:\nCompilation failed.\n\n", i+1)
 			}
 
-
 		}
 
 		// If successfully compiled, calculate score. Otherwise, score is 0. Score is calculated by lack of feedback.

--- a/grade.go
+++ b/grade.go
@@ -365,7 +365,7 @@ func main() {
 	if assignmentInfo.OutputFile != "" {
 		outFile = assignmentInfo.OutputFile
 	}
-	
+
 	if assignmentInfo.DryRun || isDryRun {
 		fmt.Println("=== Dry run - output will not be uploaded to database ===")
 	}
@@ -406,7 +406,7 @@ func main() {
 
 		results.Results[result.Student] = &result
 		results.Order = append(results.Order, result.Student)
-		
+
 		result.AssignmentId = assignmentId
 		// find hydratedStudent information from EUID (dirname)
 		hydratedStudent := db.GetStudentByEuid(supabase, result.Student)

--- a/grade.go
+++ b/grade.go
@@ -405,8 +405,11 @@ func main() {
 		for i, test := range ogInfo.Tests {
 			expected := util.GetFile(workDir + "/.spec/" + test.Expected)
 			fmt.Print("Expected Output: ", expected, "\n\n")
-
-			input := parseInFile(workDir + "/.spec/" + test.Input)
+			var input = []string{}
+			if test.Input != "" {
+				input = parseInFile(workDir + "/.spec/" + test.Input)
+			}
+			
 			gradeSubmission(&result, dir, workDir, runArgs, expected, language, input, wall, i)
 
 		}

--- a/grade_test.go
+++ b/grade_test.go
@@ -386,14 +386,12 @@ func TestGradeSubmission(t *testing.T) {
 	}
 
 	// run and validate
-	runArgs := ""
+	info := util.AssignmentInfo{Args: "", Language: "c++", Wall: false}
 	expected := "Hello World!\n"
-	language := "c++"
 	input := []string{""}
-	wall := false
 	result := util.SubmissionResult{Student: "jgg0144", CompileSuccess: false, Score: 0, Feedback: []string{""}, AssignmentId: 1, StudentId: 1}
 
-	gradeSubmission(&result, dir, workDir, runArgs, expected, language, input, wall, 0)
+	gradeSubmission(&result, dir, workDir, expected, input, 0, info)
 
 	if !result.CompileSuccess {
 		t.Fatalf("Compile error")

--- a/grade_test.go
+++ b/grade_test.go
@@ -144,7 +144,7 @@ func TestCreateCsv(t *testing.T) {
 
 	createCsv(res, tmp.Name())
 
-	expected := `student,compiled,ran correctly,feedback
+	expected := `student,compiled,score,feedback
 aaa0001,true,100,<diff1>
 bbb0002,true,50,<diff2>
 ccc0003,false,50,<diff3>

--- a/util/main.go
+++ b/util/main.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 )
 
 // Collection of submission results. Includes an order array to indicate the order of items in the
@@ -14,25 +16,36 @@ type SubmissionResults struct {
 
 // Record of a student's submission, with metadata about how it ran and compiled.
 type SubmissionResult struct {
-	Student        string
-	CompileSuccess bool
-	RunCorrect     bool
-	Feedback       string
-	AssignmentId   int8
-	StudentId      int8
+	Student        	string
+	CompileSuccess 	bool
+	Score						int8
+	Feedback       	[]string
+	AssignmentId   	int8
+	StudentId      	int8
+}
+
+type Test struct {
+	Expected 	string 	`json:"Expected"`
+	Input 		string	`json:"Input"`
+	Weight 		int8		`json:"Weight"`
 }
 
 type AssignmentInfo struct {
-	AssignmentId int8
+	AssignmentId 	int8		`json:"AssignmentId"`
+	Tests 				[]Test	`json:"Tests"`
 }
 
-func CalculateScore(result SubmissionResult) (score int) {
-	if result.CompileSuccess {
-		score += 50
+func CalculateScore(result SubmissionResult, tests []Test) (score int) {
+	var scorePossible int = 0
+	var scoreEarned int = 0
+	for i, feedback := range result.Feedback {
+		scorePossible += int(tests[i].Weight)
+		if feedback == "" {
+			scoreEarned += int(tests[i].Weight)
+		}
 	}
-	if result.RunCorrect {
-		score += 50
-	}
+
+	score = int((float64(scoreEarned) / float64(scorePossible)) * 100)
 	return
 }
 
@@ -61,4 +74,15 @@ func ParseOgInfo(path string) (info AssignmentInfo) {
 
 	json.Unmarshal(data, &info)
 	return
+}
+
+// Helper method to turn string slice into a readable, new line separated string that will print well in the report
+func StringSliceToPrettyString(input []string) string {
+	var output string = ""
+	for _, str := range input {
+		if str != "" {
+			output += fmt.Sprintf("%s\n", str)
+		}
+	}
+	return strings.TrimSpace(output)
 }

--- a/util/main.go
+++ b/util/main.go
@@ -31,12 +31,6 @@ type Test struct {
 	Open 			bool		`json:"Open"`
 }
 
-type Test struct {
-	Expected string `json:"Expected"`
-	Input    string `json:"Input"`
-	Weight   int8   `json:"Weight"`
-}
-
 type AssignmentInfo struct {
 	AssignmentId 	int8		`json:"AssignmentId"`
 	Args 					string	`json:"Args"`

--- a/util/main.go
+++ b/util/main.go
@@ -33,7 +33,18 @@ type Test struct {
 
 type AssignmentInfo struct {
 	AssignmentId 	int8		`json:"AssignmentId"`
+	Args 					string	`json:"Args"`
+	DryRun 				bool		`json:"DryRun"`
+	Language 			string	`json:"Language"`
+	OutputFile 		string	`json:"OutputFile"`
+	Wall					bool 		`json:"Wall"`
 	Tests 				[]Test	`json:"Tests"`
+}
+
+type StudentInfo struct {
+	StudentEuid 	string	`json:"StudentEuid"`
+	StudentName 	string	`json:"StudentName"`
+	StudentEmail 	string	`json:"StudentEmail"`
 }
 
 func CalculateScore(result SubmissionResult, tests []Test) (score int) {
@@ -65,7 +76,20 @@ func GetFile(fp string) string {
 }
 
 // Parse the oginfo.json file into the AssignmentInfo struct
-func ParseOgInfo(path string) (info AssignmentInfo) {
+func ParseAssignmentOgInfo(path string) (info AssignmentInfo) {
+	// manually reading file bc need to fail gracefully
+	data, err := os.ReadFile(path)
+
+	if err != nil {
+		return
+	}
+
+	json.Unmarshal(data, &info)
+	return
+}
+
+// Parse the oginfo.json file into the AssignmentInfo struct
+func ParseStudentOgInfo(path string) (info StudentInfo) {
 	// manually reading file bc need to fail gracefully
 	data, err := os.ReadFile(path)
 

--- a/util/main.go
+++ b/util/main.go
@@ -28,6 +28,7 @@ type Test struct {
 	Expected 	string 	`json:"Expected"`
 	Input 		string	`json:"Input"`
 	Weight 		int8		`json:"Weight"`
+	Open 			bool		`json:"Open"`
 }
 
 type AssignmentInfo struct {

--- a/util/main.go
+++ b/util/main.go
@@ -16,35 +16,35 @@ type SubmissionResults struct {
 
 // Record of a student's submission, with metadata about how it ran and compiled.
 type SubmissionResult struct {
-	Student        	string
-	CompileSuccess 	bool
-	Score						int8
-	Feedback       	[]string
-	AssignmentId   	int8
-	StudentId      	int8
+	Student        string
+	CompileSuccess bool
+	Score          int8
+	Feedback       []string
+	AssignmentId   int8
+	StudentId      int8
 }
 
 type Test struct {
-	Expected 	string 	`json:"Expected"`
-	Input 		string	`json:"Input"`
-	Weight 		int8		`json:"Weight"`
-	Open 			bool		`json:"Open"`
+	Expected string `json:"Expected"`
+	Input    string `json:"Input"`
+	Weight   int8   `json:"Weight"`
+	Open     bool   `json:"Open"`
 }
 
 type AssignmentInfo struct {
-	AssignmentId 	int8		`json:"AssignmentId"`
-	Args 					string	`json:"Args"`
-	DryRun 				bool		`json:"DryRun"`
-	Language 			string	`json:"Language"`
-	OutputFile 		string	`json:"OutputFile"`
-	Wall					bool 		`json:"Wall"`
-	Tests 				[]Test	`json:"Tests"`
+	AssignmentId int8   `json:"AssignmentId"`
+	Args         string `json:"Args"`
+	DryRun       bool   `json:"DryRun"`
+	Language     string `json:"Language"`
+	OutputFile   string `json:"OutputFile"`
+	Wall         bool   `json:"Wall"`
+	Tests        []Test `json:"Tests"`
 }
 
 type StudentInfo struct {
-	StudentEuid 	string	`json:"StudentEuid"`
-	StudentName 	string	`json:"StudentName"`
-	StudentEmail 	string	`json:"StudentEmail"`
+	StudentEuid  string `json:"StudentEuid"`
+	StudentName  string `json:"StudentName"`
+	StudentEmail string `json:"StudentEmail"`
 }
 
 func CalculateScore(result SubmissionResult, tests []Test) (score int) {
@@ -101,7 +101,7 @@ func ParseStudentOgInfo(path string) (info StudentInfo) {
 
 	unmarshalErr := json.Unmarshal(data, &info)
 	Throw(unmarshalErr)
-	
+
 	return
 }
 
@@ -115,4 +115,3 @@ func StringSliceToPrettyString(input []string) string {
 	}
 	return strings.TrimSpace(output)
 }
-

--- a/util/main.go
+++ b/util/main.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -103,6 +104,49 @@ func ParseStudentOgInfo(path string) (info StudentInfo) {
 	Throw(unmarshalErr)
 
 	return
+}
+
+func EnforceFlagPrecedence(info *AssignmentInfo, runArgs, outFile, language string, wall, isDryRun bool, assignmentId int) {
+	if isFlagPassed("args") {
+		fmt.Println("args passed")
+		info.Args = runArgs
+	}
+
+	if isFlagPassed("out") {
+		fmt.Println("out passed")
+		info.OutputFile = outFile
+	}
+
+	if isFlagPassed("lang") {
+		fmt.Println("lang passed")
+		info.Language = language
+	}
+
+	if isFlagPassed("Wall") {
+		fmt.Println("Wall passed")
+		info.Wall = wall
+	}
+
+	if isFlagPassed("dry-run") {
+		fmt.Println("dry-run passed")
+		info.DryRun = isDryRun
+	}
+
+	if isFlagPassed("assignment-id") {
+		fmt.Println("assignment-id passed")
+		info.AssignmentId = int8(assignmentId)
+	}
+}
+
+// helper method to check if a flag has been passed | src: https://stackoverflow.com/questions/35809252/check-if-flag-was-provided-in-go
+func isFlagPassed(name string) bool {
+	found := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == name {
+			found = true
+		}
+	})
+	return found
 }
 
 // Helper method to turn string slice into a readable, new line separated string that will print well in the report

--- a/util/main.go
+++ b/util/main.go
@@ -88,7 +88,7 @@ func ParseAssignmentOgInfo(path string) (info AssignmentInfo) {
 	return
 }
 
-// Parse the oginfo.json file into the AssignmentInfo struct
+// Parse the oginfo.json file into the StudentInfo struct
 func ParseStudentOgInfo(path string) (info StudentInfo) {
 	// manually reading file bc need to fail gracefully
 	data, err := os.ReadFile(path)

--- a/util/main.go
+++ b/util/main.go
@@ -99,7 +99,9 @@ func ParseStudentOgInfo(path string) (info StudentInfo) {
 		return
 	}
 
-	json.Unmarshal(data, &info)
+	unmarshalErr := json.Unmarshal(data, &info)
+	Throw(unmarshalErr)
+	
 	return
 }
 

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -213,6 +213,26 @@ func TestParseAssignmentOgInfo(t *testing.T) {
 		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
 	}
 
+	if got.DryRun != want.DryRun {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
+	if got.Args != want.Args {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
+	if got.Language != want.Language {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
+	if got.OutputFile != want.OutputFile {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
+	if got.Wall != want.Wall {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
 	for i := range got.Tests {
 		if got.Tests[i].Expected != want.Tests[i].Expected {
 			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -137,21 +137,25 @@ func TestParseOgInfo(t *testing.T) {
 				Expected: "test1/out.txt",
 				Input: "test1/in.txt",
 				Weight: 50,
+				Open: true,
 			},
 			{
 				Expected: "test2/out.txt",
 				Input: "test2/in.txt",
 				Weight: 10,
+				Open: false,
 			},
 			{
 				Expected: "test3/out.txt",
 				Input: "test3/in.txt",
 				Weight: 15,
+				Open: false,
 			},
 			{
 				Expected: "test4/out.txt",
 				Input: "test4/in.txt",
 				Weight: 25,
+				Open: true,
 			},
 		},
 	}
@@ -164,23 +168,26 @@ func TestParseOgInfo(t *testing.T) {
 			{
 				"Expected": "test1/out.txt",
 				"Input": "test1/in.txt",
-				"Weight": 50
+				"Weight": 50,
+				"Open": true
 			},
 			{
 				"Expected": "test2/out.txt",
 				"Input": "test2/in.txt",
-				"Weight": 10
-
+				"Weight": 10,
+				"Open": false
 			},
 			{
 				"Expected": "test3/out.txt",
 				"Input": "test3/in.txt",
-				"Weight": 15
+				"Weight": 15,
+				"Open": false
 			},
 			{
 				"Expected": "test4/out.txt",
 				"Input": "test4/in.txt",
-				"Weight": 25
+				"Weight": 25,
+				"Open": true
 			} 
 		]
 	}`
@@ -204,6 +211,10 @@ func TestParseOgInfo(t *testing.T) {
 			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
 		}
 		if got.Tests[i].Weight != want.Tests[i].Weight {
+			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+		}
+
+		if got.Tests[i].Open != want.Tests[i].Open {
 			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
 		}
 	}

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -42,12 +42,12 @@ func TestCalculateScore(t *testing.T) {
 			SubmissionResult{
 				Student:        "test",
 				CompileSuccess: true,
-				Score:        0,	
-				Feedback:     []string{"", "test"},
-				AssignmentId: 1,
-				StudentId:    1,
+				Score:          0,
+				Feedback:       []string{"", "test"},
+				AssignmentId:   1,
+				StudentId:      1,
 			},
-			[]Test{	
+			[]Test{
 				{
 					Expected: "test",
 					Input:    "test",
@@ -132,35 +132,35 @@ func TestParseAssignmentOgInfo(t *testing.T) {
 
 	var want = AssignmentInfo{
 		AssignmentId: 1,
-		Args: "",
-		DryRun: true,
-		Language: "c++",
-		OutputFile: "Report1.csv",
-		Wall: false,
+		Args:         "",
+		DryRun:       true,
+		Language:     "c++",
+		OutputFile:   "Report1.csv",
+		Wall:         false,
 		Tests: []Test{
 			{
 				Expected: "test1/out.txt",
-				Input: "test1/in.txt",
-				Weight: 50,
-				Open: true,
+				Input:    "test1/in.txt",
+				Weight:   50,
+				Open:     true,
 			},
 			{
 				Expected: "test2/out.txt",
-				Input: "test2/in.txt",
-				Weight: 10,
-				Open: false,
+				Input:    "test2/in.txt",
+				Weight:   10,
+				Open:     false,
 			},
 			{
 				Expected: "test3/out.txt",
-				Input: "test3/in.txt",
-				Weight: 15,
-				Open: false,
+				Input:    "test3/in.txt",
+				Weight:   15,
+				Open:     false,
 			},
 			{
 				Expected: "test4/out.txt",
-				Input: "test4/in.txt",
-				Weight: 25,
-				Open: true,
+				Input:    "test4/in.txt",
+				Weight:   25,
+				Open:     true,
 			},
 		},
 	}
@@ -204,7 +204,7 @@ func TestParseAssignmentOgInfo(t *testing.T) {
 	defer os.Remove(tmp.Name())
 
 	os.WriteFile(tmp.Name(), []byte(oginfo), os.ModeAppend)
-	
+
 	got := ParseAssignmentOgInfo(tmp.Name())
 
 	if got.AssignmentId != want.AssignmentId {
@@ -250,8 +250,8 @@ func TestParseAssignmentOgInfo(t *testing.T) {
 
 func TestParseStudentInfo(t *testing.T) {
 	var want = StudentInfo{
-		StudentEuid: "jjd1234",
-		StudentName: "John Doe",
+		StudentEuid:  "jjd1234",
+		StudentName:  "John Doe",
 		StudentEmail: "JohnDoe@my.unt.edu",
 	}
 

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -2,7 +2,6 @@ package util
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"testing"
 )
@@ -10,44 +9,64 @@ import (
 // Write unit tests for the util package.
 
 func TestCalculateScore(t *testing.T) {
+	// Test cases for CalculateScore
 	var tests = []struct {
 		result SubmissionResult
+		tests  []Test
 		want   int
 	}{
 		{
 			SubmissionResult{
+				Student:        "test",
 				CompileSuccess: true,
-				RunCorrect:     true,
+				Score:          0,
+				Feedback:       []string{"", ""},
+				AssignmentId:   1,
+				StudentId:      1,
+			},
+			[]Test{
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
 			},
 			100,
 		},
 		{
 			SubmissionResult{
-				CompileSuccess: false,
-				RunCorrect:     true,
-			},
-			50,
-		},
-		{
-			SubmissionResult{
+				Student:        "test",
 				CompileSuccess: true,
-				RunCorrect:     false,
+				Score:        0,	
+				Feedback:     []string{"", "test"},
+				AssignmentId: 1,
+				StudentId:    1,
+			},
+			[]Test{	
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
+				{
+					Expected: "test",
+					Input:    "test",
+					Weight:   1,
+				},
 			},
 			50,
-		},
-		{
-			SubmissionResult{
-				CompileSuccess: false,
-				RunCorrect:     false,
-			},
-			0,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run("TestCalculateScore", func(t *testing.T) {
-			if got := CalculateScore(test.result); got != test.want {
-				t.Errorf("CalculateScore(%v) = %v, want %v", test.result, got, test.want)
+			if got := CalculateScore(test.result, test.tests); got != test.want {
+				t.Errorf("CalculateScore(%v, %v) = %v, want %v", test.result, test.tests, got, test.want)
 			}
 		})
 	}
@@ -110,34 +129,83 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestParseOgInfo(t *testing.T) {
-	var tests = []struct {
-		path string
-		want AssignmentInfo
-	}{
-		{
-			"test.json",
-			AssignmentInfo{
-				AssignmentId: 1,
+
+	var want = AssignmentInfo{
+		AssignmentId: 1,
+		Tests: []Test{
+			{
+				Expected: "test1/out.txt",
+				Input: "test1/in.txt",
+				Weight: 50,
 			},
-		},
-		{
-			"test2.json",
-			AssignmentInfo{
-				AssignmentId: 2,
+			{
+				Expected: "test2/out.txt",
+				Input: "test2/in.txt",
+				Weight: 10,
+			},
+			{
+				Expected: "test3/out.txt",
+				Input: "test3/in.txt",
+				Weight: 15,
+			},
+			{
+				Expected: "test4/out.txt",
+				Input: "test4/in.txt",
+				Weight: 25,
 			},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run("TestParseOgInfo", func(t *testing.T) {
-			target, _ := os.CreateTemp("", test.path)
-			defer os.Remove(target.Name())
 
-			os.WriteFile(target.Name(), []byte(fmt.Sprintf(`{"assignmentId": %d}`, test.want.AssignmentId)), os.ModeAppend)
 
-			if got := ParseOgInfo(target.Name()); got != test.want {
-				t.Errorf("ParseOgInfo(%v) = %v, want %v", test.path, got, test.want)
-			}
-		})
+	oginfo := `{
+		"AssignmentId": 1,
+		"Tests": [
+			{
+				"Expected": "test1/out.txt",
+				"Input": "test1/in.txt",
+				"Weight": 50
+			},
+			{
+				"Expected": "test2/out.txt",
+				"Input": "test2/in.txt",
+				"Weight": 10
+
+			},
+			{
+				"Expected": "test3/out.txt",
+				"Input": "test3/in.txt",
+				"Weight": 15
+			},
+			{
+				"Expected": "test4/out.txt",
+				"Input": "test4/in.txt",
+				"Weight": 25
+			} 
+		]
+	}`
+
+	tmp, _ := os.CreateTemp("", "test.json")
+	defer os.Remove(tmp.Name())
+
+	os.WriteFile(tmp.Name(), []byte(oginfo), os.ModeAppend)
+	
+	got := ParseOgInfo(tmp.Name())
+
+	if got.AssignmentId != want.AssignmentId {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
 	}
+
+	for i := range got.Tests {
+		if got.Tests[i].Expected != want.Tests[i].Expected {
+			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+		}
+		if got.Tests[i].Input != want.Tests[i].Input {
+			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+		}
+		if got.Tests[i].Weight != want.Tests[i].Weight {
+			t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+		}
+	}
+
 }

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -128,10 +128,15 @@ func TestGetFile(t *testing.T) {
 	}
 }
 
-func TestParseOgInfo(t *testing.T) {
+func TestParseAssignmentOgInfo(t *testing.T) {
 
 	var want = AssignmentInfo{
 		AssignmentId: 1,
+		Args: "",
+		DryRun: true,
+		Language: "c++",
+		OutputFile: "Report1.csv",
+		Wall: false,
 		Tests: []Test{
 			{
 				Expected: "test1/out.txt",
@@ -164,6 +169,11 @@ func TestParseOgInfo(t *testing.T) {
 
 	oginfo := `{
 		"AssignmentId": 1,
+		"Args": "",
+		"DryRun": true,
+		"Language": "c++",
+		"OutputFile": "Report1.csv",
+		"Wall": false,
 		"Tests": [
 			{
 				"Expected": "test1/out.txt",
@@ -197,7 +207,7 @@ func TestParseOgInfo(t *testing.T) {
 
 	os.WriteFile(tmp.Name(), []byte(oginfo), os.ModeAppend)
 	
-	got := ParseOgInfo(tmp.Name())
+	got := ParseAssignmentOgInfo(tmp.Name())
 
 	if got.AssignmentId != want.AssignmentId {
 		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)

--- a/util/main_test.go
+++ b/util/main_test.go
@@ -250,3 +250,37 @@ func TestParseAssignmentOgInfo(t *testing.T) {
 	}
 
 }
+
+func TestParseStudentInfo(t *testing.T) {
+	var want = StudentInfo{
+		StudentEuid: "jjd1234",
+		StudentName: "John Doe",
+		StudentEmail: "JohnDoe@my.unt.edu",
+	}
+
+	studentinfo := `{
+		"StudentEuid": "jjd1234",
+		"StudentName": "John Doe",
+		"StudentEmail": "JohnDoe@my.unt.edu"
+	}`
+
+	tmp, _ := os.CreateTemp("", "test.json")
+	defer os.Remove(tmp.Name())
+
+	os.WriteFile(tmp.Name(), []byte(studentinfo), os.ModeAppend)
+
+	got := ParseStudentOgInfo(tmp.Name())
+
+	if got.StudentEuid != want.StudentEuid {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
+	if got.StudentName != want.StudentName {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
+	if got.StudentEmail != want.StudentEmail {
+		t.Errorf("ParseOgInfo(%v) = %v, want %v", tmp.Name(), got, want)
+	}
+
+}


### PR DESCRIPTION
Expanded on what can be pulled from `.spec/oginfo.json` (class level) and added support for an `oginfo.json` in each individual submission folder (student level) to pull student metadata such as euid, name, and email.

 Now by using `.spec/oginfo.json`, the only necessary flag to pass is `-directory`.

Class level JSON schema:
```json
{
    "AssignmentId": 4,
    "Args": "",
    "DryRun": true,
    "Language": "c++",
    "OutputFile": "Assignment4Report.csv",
    "Wall": false,
    "Tests": [
      {
        "Expected": "test1/out.txt",
        "Input": "test1/in.txt",
        "Weight": 50,
        "Open": true
      },
      {
        "Expected": "test2/out.txt",
        "Input": "test2/in.txt",
        "Weight": 10,
        "Open": false
      },
      {
        "Expected": "test3/out.txt",
        "Input": "test3/in.txt",
        "Weight": 15,
        "Open": false
      },
      {
        "Expected": "test4/out.txt",
        "Input": "test4/in.txt",
        "Weight": 25,
        "Open": true
      } 
    ]
}
```

Student level JSON schema:
```json
{
  "StudentEuid": "dcf0085",
  "StudentName": "Dayton Forehand",
  "StudentEmail": "DaytonForehand@my.unt.edu"
}
```

Corresponding submissions directory schema:
```txt
Submissions/
├── .spec
│   ├── oginfo.json
│   ├── test1
│   │   ├── in.txt
│   │   └── out.txt
│   ├── test2
│   │   ├── in.txt
│   │   └── out.txt
│   ├── test3
│   │   ├── in.txt
│   │   └── out.txt
│   └── test4
│       ├── in.txt
│       └── out.txt
├── <insert_any_dir_name>
│   ├── oginfo.json
│   └── <filename>.cpp
├── <insert_any_dir_name>
│   ├── oginfo.json
│   └── <filename>.cpp
└──...
```

In the case that there are conflicts between passed flags and class level `oginfo.json`'s values, the flags will take precedence. However in a student level `oginfo.json`, if an euid is found within the json it will take priority over the directory name.

Additionally, the `Tests` field is **mandatory** and must be included in the `.spec/oginfo.json` for the engine to function properly.