### PR TITLE
Fix to inconsistent grading

### DIFF
--- a/api.go
+++ b/api.go
@@ -192,7 +192,9 @@ func Server() {
 				} else {
 					result.CompileSuccess = compile(filepath.Join(workDir, dir), assignment.Language, false)
 					if result.CompileSuccess {
-						stdout := runCompiled(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input)
+						c := make(chan string)
+						go runCompiled(filepath.Join(workDir, dir), assignment.Args, assignment.Language, input, c)
+						stdout := <-c
 						result.Feedback[0] = processOutput(expected, stdout)
 					}
 				}

--- a/grade_test.go
+++ b/grade_test.go
@@ -262,7 +262,10 @@ func TestRunCompiled(t *testing.T) {
 	}
 
 	expected := "Hello world!\n"
-	actual := runCompiled(dir, tmp.Name(), "c++", []string{})
+
+	c := make(chan string)
+	go runCompiled(dir, tmp.Name(), "c++", []string{}, c)
+	actual := <-c
 
 	if expected != actual {
 		t.Errorf("Expected text did not match actual [expected=%#v] [actual=%#v]", expected, actual)


### PR DESCRIPTION
I believe I've fixed the issue where the engine doesn't grade consistently. The changes were small but noteworthy:

1. `runCompiled()` now has an additional parameter and no longer returns a string. The last parameter should be a string channel that `runCompiled` will now write to at the end of the function. Read from the passed channel by using `result <- ch` after passing `ch` into `runCompiled`.
2. Rather than pointing `cmd.Stdout` to our declared `CmdOutput stdout` object, we use `stdout, err := cmd.StdoutPipe()` to read from the submission subprocess. 

This still needs to be tested on other machines / in other ecosystems, but in the 40+ tests I've run I have yet to receive an inaccurate grade.